### PR TITLE
fix(nav): correct type in resume link

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -362,7 +362,7 @@ const App = () => {
                         # Contact
                     </NavOption>
                     <NavOptionHighlighted
-                        href="/resume.pdf"
+                        href="resume.pdf"
                         rel="noopener noreferrer"
                         target="_blank"
                     >


### PR DESCRIPTION
`/resume.pdf` -> `resume.pdf` to account for differing routes in react dev server vs. Github Pages